### PR TITLE
Test green ci

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,0 +1,9 @@
+# Changes here will be overwritten by Copier
+_commit: b7465b3
+_src_path: https://github.com/Cambridge-ICCS/green-ci.git
+build_docs_timeout: 15
+build_docs_triggers:
+- .github/workflows/build_docs.yml
+- docs/*.md
+- docs/*.html
+carbon_aware: true

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,47 @@
+# Workflow to build and deploy docs for the project
+name: BuildDocs
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on pushes to the "main" branch, i.e., PR merges
+  push:
+    branches: [ "main" ]
+
+  # Triggers the workflow on pushes to open pull requests to main with documentation changes
+  pull_request:
+    branches: [ "main" ]
+    paths: ['.github/workflows/build_docs.yml', 'docs/*.md', 'docs/*.html']
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Helps prevent parallel runs of the workflow from overlapping
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Workflow run - one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build-docs"
+  build-docs:
+    # The timeout minutes for the job to complete
+    timeout-minutes: 15
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Start Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4 # use hash or @vX here (See note below)
+        with:
+          task: start-measurement
+        continue-on-error: true
+
+      # TODO: Add your other steps here
+
+      - name: Show Energy Results
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4 # use hash or @vX here (See note below)
+        with:
+          task: display-results
+        continue-on-error: true
+      


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate building and deploying documentation, along with configuration updates to support carbon-aware CI practices. The workflow is designed to trigger on relevant documentation changes and includes steps for measuring and displaying energy usage during the build process.

**CI/CD and Documentation Automation:**

* Added a new workflow file, `build_docs.yml`, to `.github/workflows/` that:
  * Triggers on pushes to `main`, pull requests affecting documentation files, and manual dispatches.
  * Runs a job on `ubuntu-latest` with a 15-minute timeout.
  * Integrates steps to start and display energy usage measurement using the `eco-ci-energy-estimation` GitHub Action.

**Configuration Updates:**

* Updated `.copier-answers.yml` to:
  * Set a 15-minute documentation build timeout.
  * Define triggers for documentation builds.
  * Enable carbon-aware CI by setting `carbon_aware: true`.